### PR TITLE
Remove the "r" from the beggining of the version name

### DIFF
--- a/io.jamulus.Jamulus.metainfo.xml
+++ b/io.jamulus.Jamulus.metainfo.xml
@@ -21,6 +21,6 @@
     <content_attribute id="social-audio">intense</content_attribute>
   </content_rating>
   <releases>
-    <release version="r3_6_2" date="2020-12-12"/>
+    <release version="3_6_2" date="2020-12-12"/>
   </releases>
 </component>


### PR DESCRIPTION
Avoid conflicts with version fetched from release-monitor