### PR TITLE
No need to rollback to older pipewire?

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use this package, you need to have [pipewire](https://pipewire.org/) set up i
 
 In Fedora 34, that will be the default audio handler. On previous versions, you can do that with:
 ```
-sudo dnf install --allowerasing pipewire-libjack
+sudo dnf install pipewire-jack-audio-connection-kit
 ```
 (more info at https://fedoraproject.org/wiki/Changes/DefaultPipeWire#How_To_Test)
 


### PR DESCRIPTION
I was looking at https://pkgs.org/search/?q=pw-jack&on=files and it seems that the `pw-jack` binary was provided by `pipewire-libjack-0.3.13-4.fc33.x86_64.rpm` when Fedora 33 was born, but nowadays it comes from `pipewire-jack-audio-connection-kit-0.3.22-4.fc33.x86_64.rpm`.

It seems this one is a better solution for installing the dependency, because it doesn't require to downgrade pipewire. Actually this way I was able to install the dependency on Silverblue.