### PR TITLE
Add and update metadata in manifest

### DIFF
--- a/io.jamulus.Jamulus.metainfo.xml
+++ b/io.jamulus.Jamulus.metainfo.xml
@@ -2,12 +2,14 @@
 <component type="desktop">
   <id>io.jamulus.Jamulus</id>
   <metadata_license>MIT</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <name>Jamulus</name>
-  <developer_name>Jamulus</developer_name>
+  <developer_name>The Jamulus Development Team</developer_name>
   <url type="homepage">https://jamulus.io</url>
+  <url type="help">https://github.com/orgs/jamulussoftware/discussions</url>
   <summary>Jamulus. Internet Jam Session Software</summary>
   <description>
-    <p>The Jamulus software enables musicians to perform real-time jam sessions over the internet</p>
+    <p>The Jamulus software enables musicians to rehearse, play music or perform real-time jam sessions over the internet</p>
     <p>This is the build of Jamulus, packaged into a Flatpak.</p>
   </description>
   <screenshots>


### PR DESCRIPTION
Adds more metadata to the mainifest file. Also adds the correct license.

Fixes: #70 

Gnome Software now shows it's licensed correctly (and also the help page)

![license](https://user-images.githubusercontent.com/20726856/229043523-3582d6eb-d2cf-4eac-b9cd-2a2f1f2c1203.png)
